### PR TITLE
init: rescript-nock

### DIFF
--- a/packages/rescript-nock/README.md
+++ b/packages/rescript-nock/README.md
@@ -1,0 +1,53 @@
+# `rescript-nock`
+
+ReScript binding of [nock](https://github.com/nock/nock)
+
+## Install
+
+```bash
+npm i @greenlabs/rescript-nock --save-dev
+or
+yarn add @greenlabs/rescript-nock --dev
+```
+
+```json
+"bs-dev-dependencies": [
+  "@greenlabs/rescript-nock"
+]
+```
+
+## Usage
+
+With [rescript-jest](https://github.com/green-labs/rescript-bindings/packages/rescript-jest)
+
+```rescript
+open Jest
+open Expect
+
+describe("Test my module", () => {
+  let setupNetworkScope = Nock.make("https://greenlabs.co.kr")
+    ->Nock.get("/api/communities")
+    ->Nock.replyAny(200, {
+      "result": "OK"
+    })
+  describe("When call setup", () => {
+    testPromise("Should network is mocked", () => {
+      let scope = setupNetworkScope()
+
+      Fetch.fetch("https://greenlabs.co.kr/api/communities")
+      ->Promise.then(response => response->Fetch.Response.json)
+      ->Promise.thenResolve(response => {
+        expect(
+          response
+          ->Js.Json.decodeObject
+          ->Belt.Option.flatMap(
+            object => object->Js.Dict.get("result")->Belt.Option.flatMap(Js.Json.decodeString),
+          ),
+        )->toBe(Some("OK"))
+        scope->Nock.done
+      })
+    })
+  })
+  
+})
+```

--- a/packages/rescript-nock/bsconfig.json
+++ b/packages/rescript-nock/bsconfig.json
@@ -1,0 +1,21 @@
+
+{
+  "name": "@greenlabs/rescript-nock",
+  "reason": { "react-jsx": 3 },
+  "package-specs": {
+    "module": "es6",
+    "in-source": true
+  },
+  "suffix": ".bs.js",
+  "sources": [
+    {
+      "dir": "./src",
+      "subdirs": false
+    }
+  ],
+  "bsc-flags": ["-bs-no-version-header"],
+  "warnings": {
+    "error": true
+  },
+  "bs-dependencies": ["rescript-webapi"]
+}

--- a/packages/rescript-nock/package.json
+++ b/packages/rescript-nock/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@greenlabs/rescript-nock",
+  "description": "ReScript bindings for Nock",
+  "version": "0.0.0",
+  "license": "MIT",
+  "author": "Greenlabs Dev <developer@greenlabs.co.kr>",
+  "scripts": {
+    "start": "rescript build -w",
+    "build": "rescript build -with-deps"
+  },
+  "keywords": [
+    "ReScript",
+    "Nock"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "bugs": "https://github.com/green-labs/rescript-bindings/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/green-labs/rescript-bindings.git",
+    "directory": "packages/rescript-nock"
+  },
+  "peerDependencies": {
+    "nock": "^13.2.9",
+    "rescript-webapi": "^0.6.1"
+  }
+}

--- a/packages/rescript-nock/src/Nock.bs.js
+++ b/packages/rescript-nock/src/Nock.bs.js
@@ -1,0 +1,1 @@
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/packages/rescript-nock/src/Nock.res
+++ b/packages/rescript-nock/src/Nock.res
@@ -1,0 +1,90 @@
+type t
+type t2
+
+@module("nock") external make: string => t = "default"
+@module("nock") external makeRegex: Js.Re.t => t = "default"
+
+// mock network
+@module("nock") external disableNetConnect: unit => unit = "disableNetConnect"
+@module("nock") external enableNetConnect: unit => unit = "enableNetConnect"
+
+// Http methods
+@send external get: (t, string) => t2 = "get"
+@send
+external getWithRequest: (
+  t,
+  string,
+  @unwrap
+  ~request: [
+    | #Str(string)
+    | #Regex(Js.Re.t)
+    | #Json(Js.Json.t)
+    | #FnJson(Js.Json.t => bool)
+    | #FnAny('a => bool)
+    | #Any('a)
+  ]=?,
+  unit,
+) => t2 = "get"
+@send external post: (t, string) => t2 = "post"
+@send
+external postWithRequest: (
+  t,
+  string,
+  @unwrap
+  ~request: [
+    | #Str(string)
+    | #Regex(Js.Re.t)
+    | #Json(Js.Json.t)
+    | #FnJson(Js.Json.t => bool)
+    | #FnAny('a => bool)
+    | #Any('a)
+  ]=?,
+  unit,
+) => t2 = "post"
+@send external put: (t, string) => t2 = "put"
+@send
+external putWithRequest: (
+  t,
+  string,
+  @unwrap
+  [
+    | #Str(string)
+    | #Regex(Js.Re.t)
+    | #Json(Js.Json.t)
+    | #FnJson(Js.Json.t => bool)
+    | #FnAny('a => bool)
+    | #Any('a)
+  ],
+) => t2 = "put"
+@send external delete: (t, string) => t2 = "delete"
+@send
+external deleteWithRequest: (
+  t,
+  string,
+  @unwrap
+  ~request: [
+    | #Str(string)
+    | #Regex(Js.Re.t)
+    | #Json(Js.Json.t)
+    | #FnJson(Js.Json.t => bool)
+    | #FnAny('a => bool)
+    | #Any('a)
+  ]=?,
+  unit,
+) => t2 = "delete"
+
+// query
+@send external query: (t2, string) => t2 = "query"
+@send external queryJson: (t2, Js.Json.t) => t2 = "query"
+@send external querySearchParams: (t2, Webapi.Url.URLSearchParams.t) => t2 = "query"
+@send external queryAny: (t2, 'a) => t2 = "query"
+
+// reply
+@send external reply: (t2, int) => t = "reply"
+@send external replyText: (t2, int, string) => t = "reply"
+@send external replyJson: (t2, int, Js.Json.t) => t = "reply"
+@send external replyAny: (t2, int, 'a) => t = "reply"
+
+// done
+@send external done: t => unit = "done"
+@send external isDone: t => bool = "isDone"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4304,6 +4304,11 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+rescript-webapi@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/rescript-webapi/-/rescript-webapi-0.6.1.tgz#b7e578c743b08e09f259938a6e9300c238020591"
+  integrity sha512-I/eeHOcsUfWbCf6u15zd+rKxMz9awSjjdRa8eFtl2X+HjDNs0mJxoC4uFFK9dIazYcmY2VpuK5TTpOPXvdkhDw==
+
 rescript@^10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/rescript/-/rescript-10.0.1.tgz#5b2da8a8bcfb994bed1eb24820bf10cfb9d8c440"


### PR DESCRIPTION
# `rescript-nock`

ReScript binding of [nock](https://github.com/nock/nock)

## Install

```bash
npm i @greenlabs/rescript-nock --save-dev
or
yarn add @greenlabs/rescript-nock --dev
```

```json
"bs-dev-dependencies": [
  "@greenlabs/rescript-nock"
]
```

## Usage

With [rescript-jest](https://github.com/green-labs/rescript-bindings/packages/rescript-jest)

```rescript
open Jest
open Expect

describe("Test my module", () => {
  let setupNetworkScope = Nock.make("https://greenlabs.co.kr")
    ->Nock.get("/api/communities")
    ->Nock.replyAny(200, {
      "result": "OK"
    })
  describe("When call setup", () => {
    testPromise("Should network is mocked", () => {
      let scope = setupNetworkScope()

      Fetch.fetch("https://greenlabs.co.kr/api/communities")
      ->Promise.then(response => response->Fetch.Response.json)
      ->Promise.thenResolve(response => {
        expect(
          response
          ->Js.Json.decodeObject
          ->Belt.Option.flatMap(
            object => object->Js.Dict.get("result")->Belt.Option.flatMap(Js.Json.decodeString),
          ),
        )->toBe(Some("OK"))
        scope->Nock.done
      })
    })
  })
  
})
```