### PR TITLE
`@greenlabs/rescript-jest` 모듈 사용 제거, Mock.fn 타입 개선, Test.each 사용 수정

### DIFF
--- a/.changeset/curly-hornets-wonder.md
+++ b/.changeset/curly-hornets-wonder.md
@@ -1,0 +1,5 @@
+---
+"@greenlabs/rescript-jest": minor
+---
+
+remove using module (use global), fix Mock.fn, Test.each type

--- a/packages/rescript-jest/src/Jest.res
+++ b/packages/rescript-jest/src/Jest.res
@@ -50,45 +50,52 @@ module Test = {
   @scope("test")
   external each5: array<('a, 'b, 'c, 'd, 'e)> => each_fn5<'a, 'b, 'c, 'd, 'e> = "each"
 
-  @scope("test")
-  external eachPromise1: (array<'a>, string, 'a => Js.Promise.t<'t>) => unit = "each"
-  @scope("test")
-  external eachPromise2: (array<('a, 'b)>, string, ('a, 'b) => Js.Promise.t<'t>) => unit = "each"
-  @scope("test")
-  external eachPromise3: (array<('a, 'b, 'c)>, string, ('a, 'b, 'c) => Js.Promise.t<'t>) => unit =
-    "each"
-  @scope("test")
-  external eachPromise4: (
-    array<('a, 'b, 'c, 'd)>,
+  type each_promise_fn1<'a> = (string, @uncurry ('a => Js.Promise.t<unit>)) => unit
+  type each_promise_fn2<'a, 'b> = (string, @uncurry ('a, 'b) => Js.Promise.t<unit>) => unit
+  type each_promise_fn3<'a, 'b, 'c> = (string, @uncurry ('a, 'b, 'c) => Js.Promise.t<unit>) => unit
+  type each_promise_fn4<'a, 'b, 'c, 'd> = (
     string,
-    ('a, 'b, 'c, 'd) => Js.Promise.t<'t>,
-  ) => unit = "each"
-  @scope("test")
-  external eachPromise5: (
-    array<('a, 'b, 'c, 'd, 'e)>,
+    @uncurry ('a, 'b, 'c, 'd) => Js.Promise.t<unit>,
+  ) => unit
+  type each_promise_fn5<'a, 'b, 'c, 'd, 'e> = (
     string,
-    ('a, 'b, 'c, 'd, 'e) => Js.Promise.t<'t>,
-  ) => unit = "each"
+    @uncurry ('a, 'b, 'c, 'd, 'e) => Js.Promise.t<unit>,
+  ) => unit
 
   @scope("test")
-  external eachAsync1: (array<'a>, string, ('a, finishFn) => unit) => unit = "each"
+  external eachPromise1: array<'a> => each_promise_fn1<'a> = "each"
   @scope("test")
-  external eachAsync2: (array<('a, 'b)>, string, ('a, 'b, finishFn) => unit) => unit = "each"
+  external eachPromise2: array<('a, 'b)> => each_promise_fn2<'a, 'b> = "each"
   @scope("test")
-  external eachAsync3: (array<('a, 'b, 'c)>, string, ('a, 'b, 'c, finishFn) => unit) => unit =
+  external eachPromise3: array<('a, 'b, 'c)> => each_promise_fn3<'a, 'b, 'c> = "each"
+  @scope("test")
+  external eachPromise4: array<('a, 'b, 'c, 'd)> => each_promise_fn4<'a, 'b, 'c, 'd> = "each"
+  @scope("test")
+  external eachPromise5: array<('a, 'b, 'c, 'd, 'e)> => each_promise_fn5<'a, 'b, 'c, 'd, 'e> =
     "each"
-  @scope("test")
-  external eachAsync4: (
-    array<('a, 'b, 'c, 'd)>,
+
+  type each_async_fn1<'a> = (string, @uncurry ('a, finishFn) => unit) => unit
+  type each_async_fn2<'a, 'b> = (string, @uncurry ('a, 'b, finishFn) => unit) => unit
+  type each_async_fn3<'a, 'b, 'c> = (string, @uncurry ('a, 'b, 'c, finishFn) => unit) => unit
+  type each_async_fn4<'a, 'b, 'c, 'd> = (
     string,
-    ('a, 'b, 'c, 'd, finishFn) => unit,
-  ) => unit = "each"
-  @scope("test")
-  external eachAsync5: (
-    array<('a, 'b, 'c, 'd, 'e)>,
+    @uncurry ('a, 'b, 'c, 'd, finishFn) => unit,
+  ) => unit
+  type each_async_fn5<'a, 'b, 'c, 'd, 'e> = (
     string,
-    ('a, 'b, 'c, 'd, 'e, finishFn) => unit,
-  ) => unit = "each"
+    @uncurry ('a, 'b, 'c, 'd, 'e, finishFn) => unit,
+  ) => unit
+
+  @scope("test")
+  external eachAsync1: array<'a> => each_async_fn1<'a> = "each"
+  @scope("test")
+  external eachAsync2: array<('a, 'b)> => each_async_fn2<'a, 'b> = "each"
+  @scope("test")
+  external eachAsync3: array<('a, 'b, 'c)> => each_async_fn3<'a, 'b, 'c> = "each"
+  @scope("test")
+  external eachAsync4: array<('a, 'b, 'c, 'd)> => each_async_fn4<'a, 'b, 'c, 'd> = "each"
+  @scope("test")
+  external eachAsync5: array<('a, 'b, 'c, 'd, 'e)> => each_async_fn5<'a, 'b, 'c, 'd, 'e> = "each"
 }
 
 external beforeEach: (@uncurry (unit => unit)) => unit = "beforeEach"

--- a/packages/rescript-jest/src/Jest.res
+++ b/packages/rescript-jest/src/Jest.res
@@ -1,84 +1,89 @@
 // Global Functions
-@module("@jest/globals") external describe: (string, @uncurry (unit => unit)) => unit = "describe"
+external describe: (string, @uncurry (unit => unit)) => unit = "describe"
 
 type finishFn = @uncurry (unit => unit)
 
-@module("@jest/globals") external test: (string, @uncurry (unit => unit)) => unit = "test"
-@module("@jest/globals")
+external test: (string, @uncurry (unit => unit)) => unit = "test"
+
 external testPromise: (string, @uncurry (unit => Js.Promise.t<'a>)) => unit = "test"
-@module("@jest/globals") external testAsync: (string, finishFn => unit) => unit = "test"
+external testAsync: (string, finishFn => unit) => unit = "test"
 
 // test closure
 module Test = {
-  @module("@jest/globals") @scope("test")
+  @scope("test")
   external only: (string, @uncurry (unit => unit)) => unit = "only"
-  @module("@jest/globals") @scope("test")
+  @scope("test")
   external onlyPromise: (string, @uncurry (unit => Js.Promise.t<'a>)) => unit = "only"
-  @module("@jest/globals") @scope("test")
+  @scope("test")
   external onlyAsync: (string, finishFn => unit) => unit = "only"
 
-  @module("@jest/globals") @scope("test")
+  @scope("test")
   external failing: (string, @uncurry (unit => unit)) => unit = "failing"
-  @module("@jest/globals") @scope("test")
+  @scope("test")
   external failingPromise: (string, @uncurry (unit => Js.Promise.t<'a>)) => unit = "failing"
-  @module("@jest/globals") @scope("test")
+  @scope("test")
   external failingAsync: (string, finishFn => unit) => unit = "failing"
 
-  @module("@jest/globals") @scope("test")
+  @scope("test")
   external skip: (string, @uncurry (unit => unit)) => unit = "skip"
-  @module("@jest/globals") @scope("test")
+  @scope("test")
   external skipPromise: (string, @uncurry (unit => Js.Promise.t<'a>)) => unit = "skip"
-  @module("@jest/globals") @scope("test")
+  @scope("test")
   external skipAsync: (string, finishFn => unit) => unit = "skip"
 
-  @module("@jest/globals") @scope("test") external todo: string => unit = "todo"
+  @scope("test") external todo: string => unit = "todo"
 
-  @module("@jest/globals") @scope("test")
-  external each1: (array<'a>, string, 'a => unit) => unit = "each"
-  @module("@jest/globals") @scope("test")
-  external each2: (array<('a, 'b)>, string, ('a, 'b) => unit) => unit = "each"
-  @module("@jest/globals") @scope("test")
-  external each3: (array<('a, 'b, 'c)>, string, ('a, 'b, 'c) => unit) => unit = "each"
-  @module("@jest/globals") @scope("test")
-  external each4: (array<('a, 'b, 'c, 'd)>, string, ('a, 'b, 'c, 'd) => unit) => unit = "each"
-  @module("@jest/globals") @scope("test")
-  external each5: (array<('a, 'b, 'c, 'd, 'e)>, string, ('a, 'b, 'c, 'd, 'e) => unit) => unit =
-    "each"
+  type each_fn1<'a> = (string, @uncurry ('a => unit)) => unit
+  type each_fn2<'a, 'b> = (string, @uncurry ('a, 'b) => unit) => unit
+  type each_fn3<'a, 'b, 'c> = (string, @uncurry ('a, 'b, 'c) => unit) => unit
+  type each_fn4<'a, 'b, 'c, 'd> = (string, @uncurry ('a, 'b, 'c, 'd) => unit) => unit
+  type each_fn5<'a, 'b, 'c, 'd, 'e> = (string, @uncurry ('a, 'b, 'c, 'd, 'e) => unit) => unit
 
-  @module("@jest/globals") @scope("test")
+  @scope("test")
+  external each1: array<'a> => each_fn1<'a> = "each"
+  @scope("test")
+  external each2: array<('a, 'b)> => each_fn2<'a, 'b> = "each"
+  @scope("test")
+  external each3: array<('a, 'b, 'c)> => each_fn3<'a, 'b, 'c> = "each"
+  @scope("test")
+  external each4: array<('a, 'b, 'c, 'd)> => each_fn4<'a, 'b, 'c, 'd> = "each"
+  @scope("test")
+  external each5: array<('a, 'b, 'c, 'd, 'e)> => each_fn5<'a, 'b, 'c, 'd, 'e> = "each"
+
+  @scope("test")
   external eachPromise1: (array<'a>, string, 'a => Js.Promise.t<'t>) => unit = "each"
-  @module("@jest/globals") @scope("test")
+  @scope("test")
   external eachPromise2: (array<('a, 'b)>, string, ('a, 'b) => Js.Promise.t<'t>) => unit = "each"
-  @module("@jest/globals") @scope("test")
+  @scope("test")
   external eachPromise3: (array<('a, 'b, 'c)>, string, ('a, 'b, 'c) => Js.Promise.t<'t>) => unit =
     "each"
-  @module("@jest/globals") @scope("test")
+  @scope("test")
   external eachPromise4: (
     array<('a, 'b, 'c, 'd)>,
     string,
     ('a, 'b, 'c, 'd) => Js.Promise.t<'t>,
   ) => unit = "each"
-  @module("@jest/globals") @scope("test")
+  @scope("test")
   external eachPromise5: (
     array<('a, 'b, 'c, 'd, 'e)>,
     string,
     ('a, 'b, 'c, 'd, 'e) => Js.Promise.t<'t>,
   ) => unit = "each"
 
-  @module("@jest/globals") @scope("test")
+  @scope("test")
   external eachAsync1: (array<'a>, string, ('a, finishFn) => unit) => unit = "each"
-  @module("@jest/globals") @scope("test")
+  @scope("test")
   external eachAsync2: (array<('a, 'b)>, string, ('a, 'b, finishFn) => unit) => unit = "each"
-  @module("@jest/globals") @scope("test")
+  @scope("test")
   external eachAsync3: (array<('a, 'b, 'c)>, string, ('a, 'b, 'c, finishFn) => unit) => unit =
     "each"
-  @module("@jest/globals") @scope("test")
+  @scope("test")
   external eachAsync4: (
     array<('a, 'b, 'c, 'd)>,
     string,
     ('a, 'b, 'c, 'd, finishFn) => unit,
   ) => unit = "each"
-  @module("@jest/globals") @scope("test")
+  @scope("test")
   external eachAsync5: (
     array<('a, 'b, 'c, 'd, 'e)>,
     string,
@@ -86,56 +91,56 @@ module Test = {
   ) => unit = "each"
 }
 
-@module("@jest/globals") external beforeEach: (@uncurry (unit => unit)) => unit = "beforeEach"
-@module("@jest/globals")
+external beforeEach: (@uncurry (unit => unit)) => unit = "beforeEach"
+
 external beforeEachPromise: (@uncurry (unit => Js.Promise.t<'a>)) => unit = "beforeEach"
-@module("@jest/globals") external beforeEachAsync: (finishFn => unit) => unit = "beforeEach"
+external beforeEachAsync: (finishFn => unit) => unit = "beforeEach"
 
-@module("@jest/globals") external beforeAll: (@uncurry (unit => unit)) => unit = "beforeAll"
-@module("@jest/globals")
+external beforeAll: (@uncurry (unit => unit)) => unit = "beforeAll"
+
 external beforeAllPromise: (@uncurry (unit => Js.Promise.t<'a>)) => unit = "beforeAll"
-@module("@jest/globals") external beforeAllAsync: (finishFn => unit) => unit = "beforeAll"
+external beforeAllAsync: (finishFn => unit) => unit = "beforeAll"
 
-@module("@jest/globals") external afterEach: (@uncurry (unit => unit)) => unit = "afterEach"
-@module("@jest/globals")
+external afterEach: (@uncurry (unit => unit)) => unit = "afterEach"
+
 external afterEachPromise: (@uncurry (unit => Js.Promise.t<'a>)) => unit = "afterEach"
-@module("@jest/globals") external afterEachAsync: (finishFn => unit) => unit = "afterEach"
+external afterEachAsync: (finishFn => unit) => unit = "afterEach"
 
-@module("@jest/globals") external afterAll: (@uncurry (unit => unit)) => unit = "afterAll"
-@module("@jest/globals")
+external afterAll: (@uncurry (unit => unit)) => unit = "afterAll"
+
 external afterAllPromise: (@uncurry (unit => Js.Promise.t<'a>)) => unit = "afterAll"
-@module("@jest/globals") external afterAllAsync: (finishFn => unit) => unit = "afterAll"
+external afterAllAsync: (finishFn => unit) => unit = "afterAll"
 
 // Mock Module
 module Mock = {
-  type t<'args, 'return>
+  type t<'fn, 'args, 'return>
 
-  type fn<'args, 'return> = 'args => 'return
-  external fn: t<'args, 'return> => fn<'args, 'return> = "%identity"
+  external fn: t<'fn, _, _> => 'fn = "%identity"
 
-  @module("@jest/globals") @scope("jest") external empty: unit => t<'a, 'b> = "fn"
-  @module("@jest/globals") @scope("jest") external make: ('a => 'b) => t<'a, 'b> = "fn"
-  @module("@jest/globals") @scope("jest")
-  external make2: (('a, 'b) => 'return) => t<('a, 'b), 'return> = "fn"
-  @module("@jest/globals") @scope("jest")
-  external make3: (('a, 'b, 'c) => 'return) => t<('a, 'b, 'c), 'return> = "fn"
-  @module("@jest/globals") @scope("jest") external spyOn: ('spy, string) => t<'a, 'b> = "spyOn"
-  @module("@jest/globals") @scope("jest")
-  external spyOnGetter: ('spy, string, @as("json`'get'`") _) => t<'a, 'b> = "spyOn"
-  @module("@jest/globals") @scope("jest")
-  external spyOnSetter: ('spy, string, @as("json`'set'`") _) => t<'a, 'b> = "spyOn"
+  @scope("jest") external empty: unit => t<unit => unit, unit, unit> = "fn"
+  @scope("jest") external make: ('a => 'b) => t<'a => 'b, 'a, 'b> = "fn"
+  @scope("jest")
+  external make2: (('a, 'b) => 'return) => t<('a, 'b) => 'return, ('a, 'b), 'return> = "fn"
+  @scope("jest")
+  external make3: (('a, 'b, 'c) => 'return) => t<('a, 'b, 'c) => 'return, ('a, 'b, 'c), 'return> =
+    "fn"
+  @scope("jest") external spyOn: ('spy, string) => t<'a, 'b, 'c> = "spyOn"
+  @scope("jest")
+  external spyOnGetter: ('spy, string, @as("json`'get'`") _) => t<'a, 'b, 'c> = "spyOn"
+  @scope("jest")
+  external spyOnSetter: ('spy, string, @as("json`'set'`") _) => t<'a, 'b, 'c> = "spyOn"
 
   // mock property
   type return_node<'a> = {
     @as("type") type_: [#return | #throw | #incomplete],
     value: 'a,
   }
-  @get @scope("mock") external calls: t<'args, 'return> => array<'args> = "calls"
-  @get @scope("mock") external callsWrapArray: t<'args, 'return> => array<array<'args>> = "calls"
+  @get @scope("mock") external calls: t<_, 'args, _> => array<'args> = "calls"
+  @get @scope("mock") external callsWrapArray: t<_, 'args, _> => array<array<'args>> = "calls"
   @get @scope("mock")
-  external _results: t<'args, 'return> => array<return_node<'return>> = "results"
+  external _results: t<_, _, 'return> => array<return_node<'return>> = "results"
   type result_type<'return, 'error> = Return('return) | Throw('error) | Imcomplete
-  let results = (mock: t<'args, 'return>): array<result_type<'return, 'error>> => {
+  let results = (mock: t<_, _, 'return>): array<result_type<'return, 'error>> => {
     mock
     ->_results
     ->Belt.Array.map(result =>
@@ -147,161 +152,166 @@ module Mock = {
     )
   }
   @get @scope("mock")
-  external instances: t<'args, 'return> => array<'return> = "instances"
-  external lastCall: t<'args, 'return> => option<'args> = "lastCall"
-  external lastCallWrapArray: t<'args, 'return> => option<array<'args>> = "lastCall"
+  external instances: t<_, _, 'return> => array<'return> = "instances"
+  external lastCall: t<_, 'args, _> => option<'args> = "lastCall"
+  external lastCallWrapArray: t<_, 'args, _> => option<array<'args>> = "lastCall"
 
   // functions
-  @send external getMockName: t<'a, 'r> => string = "getMockName"
-  @send external setMockname: (t<'a, 'r>, string) => unit = "mockName"
-  @send external mockClear: t<'a, 'r> => unit = "mockClear"
-  @send external mockReset: t<'a, 'r> => unit = "mockReset"
-  @send external mockRestore: t<'a, 'r> => unit = "mockRestore"
-  @send external mockImplementation: (t<'a, 'r>, fn<'a, 'r>) => unit = "mockImplementation"
-  @send external mockImplementationOnce: (t<'a, 'r>, fn<'a, 'r>) => unit = "mockImplementationOnce"
-  @send external mockReturnValue: (t<'a, 'r>, 'r) => unit = "mockReturnValue"
-  @send external mockReturnValueOnce: (t<'a, 'r>, 'r) => unit = "mockReturnValueOnce"
-  @send external mockResolvedValue: (t<'a, Js.Promise.t<'r>>, 'r) => unit = "mockResolvedValue"
+  @send external getMockName: t<_, _, _> => string = "getMockName"
+  @send external setMockname: (t<_, _, _>, string) => unit = "mockName"
+  @send external mockClear: t<_, _, _> => unit = "mockClear"
+  @send external mockReset: t<_, _, _> => unit = "mockReset"
+  @send external mockRestore: t<_, _, _> => unit = "mockRestore"
+  @send external mockImplementation: (t<'fn, _, _>, 'fn) => unit = "mockImplementation"
+  @send external mockImplementationOnce: (t<'fn, _, _>, 'fn) => unit = "mockImplementationOnce"
+  @send external mockReturnValue: (t<_, _, 'return> => 'return) => unit = "mockReturnValue"
+  @send external mockReturnValueOnce: (t<_, _, 'return> => 'return) => unit = "mockReturnValueOnce"
   @send
-  external mockResolvedValueOnce: (t<'a, Js.Promise.t<'r>>, 'r) => unit = "mockResolvedValueOnce"
-  @send external mockRejectedValue: (t<'a, 'r>, 'b) => unit = "mockRejectedValue"
-  @send external mockRejectedValueOnce: (t<'a, 'r>, 'b) => unit = "mockRejectedValueOnce"
+  external mockResolvedValue: (t<_, _, Js.Promise.t<'return>>, 'return) => unit =
+    "mockResolvedValue"
+  @send
+  external mockResolvedValueOnce: (t<_, _, Js.Promise.t<'return>>, 'return) => unit =
+    "mockResolvedValueOnce"
+  @send external mockRejectedValue: (t<_, _, _>, 'b) => unit = "mockRejectedValue"
+  @send external mockRejectedValueOnce: (t<_, _, _>, 'b) => unit = "mockRejectedValueOnce"
 }
 
+type expect<'r>
 module Expect = {
-  type t<'r>
+  @get external not: expect<'a> => expect<'a> = "not"
 
-  @get external not: t<'a> => t<'a> = "not"
-
-  @send external toBe: (t<'a>, 'a) => unit = "toBe"
-  @send external toEqual: (t<'a>, 'a) => unit = "toEqual"
-  @send external toStrictEqual: (t<'a>, 'a) => unit = "toStrictEqual"
+  @send external toBe: (expect<'a>, 'a) => unit = "toBe"
+  @send external toEqual: (expect<'a>, 'a) => unit = "toEqual"
+  @send external toStrictEqual: (expect<'a>, 'a) => unit = "toStrictEqual"
 
   @send @scope("lastCalledWith")
-  external lastCalledWith: (t<Mock.t<'arg, 'return>>, Js.Nullable.t<'a>, 'b) => unit = "apply"
-  let lastCalledWith = (expect: t<Mock.t<'arg, 'return>>, argList: 'arg) =>
+  external lastCalledWith: (expect<Mock.t<_, _, _>>, Js.Nullable.t<'a>, 'b) => unit = "apply"
+  let lastCalledWith = (expect: expect<Mock.t<_, 'arg, _>>, argList: 'arg) =>
     expect->lastCalledWith(
       Js.Nullable.null,
       Js.Array2.isArray(argList) ? argList : [argList]->Obj.magic,
     )
-  @send external lastReturnedWith: (t<Mock.t<'arg, 'return>>, 'b) => unit = "lastReturnedWith"
+  @send
+  external lastReturnedWith: (expect<Mock.t<_, _, 'return>>, 'return) => unit = "lastReturnedWith"
 
   @send @scope("nthCalledWith")
-  external nthCalledWith: (t<Mock.t<'arg, 'return>>, Js.Nullable.t<'a>, 'b) => unit = "apply"
-  let nthCalledWith = (expect: t<Mock.t<'arg, 'return>>, nth: int, argList: 'arg) =>
+  external nthCalledWith: (expect<Mock.t<_, _, _>>, Js.Nullable.t<'a>, 'b) => unit = "apply"
+  let nthCalledWith = (expect: expect<Mock.t<_, 'arg, _>>, nth: int, argList: 'arg) =>
     expect->nthCalledWith(
       Js.Nullable.null,
       [nth]->Belt.Array.concat(Js.Array2.isArray(argList) ? argList : [argList]->Obj.magic),
     )
-  external nthReturnedWith: (t<Mock.t<'arg, 'return>>, int, 'b) => unit = "nthReturnedWith"
+  external nthReturnedWith: (expect<Mock.t<_, _, 'return>>, int, 'return) => unit =
+    "nthReturnedWith"
 
-  @send external toBeCalled: t<Mock.t<'arg, 'return>> => unit = "toBeCalled"
-  @send external toBeCalledTimes: (t<Mock.t<'arg, 'return>>, int) => unit = "toBeCalledTimes"
+  @send external toBeCalled: expect<Mock.t<_, _, _>> => unit = "toBeCalled"
+  @send external toBeCalledTimes: (expect<Mock.t<_, _, _>>, int) => unit = "toBeCalledTimes"
 
   @send @scope("toBeCalledWith")
-  external toBeCalledWith: (t<Mock.t<'arg, 'return>>, Js.Nullable.t<'a>, 'b) => unit = "apply"
-  let toBeCalledWith = (expect: t<Mock.t<'arg, 'return>>, argList: 'arg) =>
+  external toBeCalledWith: (expect<Mock.t<_, _, _>>, Js.Nullable.t<'a>, 'b) => unit = "apply"
+  let toBeCalledWith = (expect: expect<Mock.t<_, 'arg, _>>, argList: 'arg) =>
     expect->toBeCalledWith(
       Js.Nullable.null,
       Js.Array2.isArray(argList) ? argList : [argList]->Obj.magic,
     )
 
-  @send external toReturnedWith: (t<Mock.t<'arg, 'return>>, 'b) => unit = "toBeReturnedWith"
-
-  @send external toBeCloseTo: (t<float>, float) => unit = "toBeCloseTo"
-  @send external toBeCloseToWithDigit: (t<float>, float, int) => unit = "toBeCloseTo"
-
-  @send external toBeDefined: t<'a> => unit = "toBeDefined"
-  @send external toBeFalsy: t<'a> => unit = "toBeFalsy"
-  @send external toBeTruthy: t<'a> => unit = "toBeTruthy"
-
-  @send external toBeGreaterThan: (t<int>, int) => unit = "toBeGreaterThan"
-  @send external toBeGreaterThanOrEqual: (t<int>, int) => unit = "toBeGreaterThanOrEqual"
-  @send external toBeGreaterThanFloat: (t<float>, float) => unit = "toBeGreaterThan"
   @send
-  external toBeGreaterThanOrEqualFloat: (t<float>, float) => unit = "toBeGreaterThanOrEqual"
+  external toReturnedWith: (expect<Mock.t<_, _, 'return>>, 'return) => unit = "toBeReturnedWith"
 
-  @send external toBeLessThan: (t<int>, int) => unit = "toBeLessThan"
-  @send external toBeLessThanOrEqual: (t<int>, int) => unit = "toBeLessThanOrEqual"
-  @send external toBeLessThanFloat: (t<float>, float) => unit = "toBeLessThan"
-  @send external toBeLessThanOrEqualFloat: (t<float>, float) => unit = "toBeLessThanOrEqual"
+  @send external toBeCloseTo: (expect<float>, float) => unit = "toBeCloseTo"
+  @send external toBeCloseToWithDigit: (expect<float>, float, int) => unit = "toBeCloseTo"
 
-  @send external toBeNull: t<Js.Nullable.t<'a>> => unit = "toBeNull"
-  @send external toBeUndefined: t<Js.Undefined.t<'a>> => unit = "toBeUndefined"
+  @send external toBeDefined: expect<'a> => unit = "toBeDefined"
+  @send external toBeFalsy: expect<'a> => unit = "toBeFalsy"
+  @send external toBeTruthy: expect<'a> => unit = "toBeTruthy"
 
-  @send external toBeNaN: t<int> => unit = "toBeNaN"
-  @send external toBeNaNFloat: t<float> => unit = "toBeNaN"
+  @send external toBeGreaterThan: (expect<int>, int) => unit = "toBeGreaterThan"
+  @send external toBeGreaterThanOrEqual: (expect<int>, int) => unit = "toBeGreaterThanOrEqual"
+  @send external toBeGreaterThanFloat: (expect<float>, float) => unit = "toBeGreaterThan"
+  @send
+  external toBeGreaterThanOrEqualFloat: (expect<float>, float) => unit = "toBeGreaterThanOrEqual"
 
-  @send external toContain: (t<array<'a>>, 'a) => unit = "toContain"
-  @send external toContainEqual: (t<array<'a>>, 'a) => unit = "toContainEqual"
+  @send external toBeLessThan: (expect<int>, int) => unit = "toBeLessThan"
+  @send external toBeLessThanOrEqual: (expect<int>, int) => unit = "toBeLessThanOrEqual"
+  @send external toBeLessThanFloat: (expect<float>, float) => unit = "toBeLessThan"
+  @send external toBeLessThanOrEqualFloat: (expect<float>, float) => unit = "toBeLessThanOrEqual"
 
-  @send external toHaveLength: (t<array<'a>>, int) => unit = "toHaveLength"
-  @send external toHaveProperty: (t<'a>, string) => unit = "toHaveProperty"
-  @send external toHavePropertyValue: (t<'a>, string, 'b) => unit = "toHaveProperty"
+  @send external toBeNull: expect<Js.Nullable.t<'a>> => unit = "toBeNull"
+  @send external toBeUndefined: expect<Js.Undefined.t<'a>> => unit = "toBeUndefined"
 
-  @send external toMatch: (t<string>, Js.Re.t) => unit = "toMatch"
-  @send external toMatchString: (t<string>, string) => unit = "toMatch"
+  @send external toBeNaN: expect<int> => unit = "toBeNaN"
+  @send external toBeNaNFloat: expect<float> => unit = "toBeNaN"
 
-  @send external toMatchObject: (t<'a>, {..}) => unit = "toMatchObject"
+  @send external toContain: (expect<array<'a>>, 'a) => unit = "toContain"
+  @send external toContainEqual: (expect<array<'a>>, 'a) => unit = "toContainEqual"
 
-  @send external toMatchSnapshot: t<'a> => unit = "toMatchSnapshot"
-  @send external toMatchInlineSnapshot: t<'a> => unit = "toMatchInlineSnapshot"
+  @send external toHaveLength: (expect<array<'a>>, int) => unit = "toHaveLength"
+  @send external toHaveProperty: (expect<'a>, string) => unit = "toHaveProperty"
+  @send external toHavePropertyValue: (expect<'a>, string, 'b) => unit = "toHaveProperty"
 
-  @send external toThrow: t<unit => unit> => unit = "toThrow"
-  @send external toThrowError: (t<unit => unit>, Js.Exn.t) => unit = "toThrow"
+  @send external toMatch: (expect<string>, Js.Re.t) => unit = "toMatch"
+  @send external toMatchString: (expect<string>, string) => unit = "toMatch"
+
+  @send external toMatchObject: (expect<'a>, {..}) => unit = "toMatchObject"
+
+  @send external toMatchSnapshot: expect<'a> => unit = "toMatchSnapshot"
+  @send external toMatchInlineSnapshot: expect<'a> => unit = "toMatchInlineSnapshot"
+
+  @send external toThrow: expect<unit => unit> => unit = "toThrow"
+  @send external toThrowError: (expect<unit => unit>, Js.Exn.t) => unit = "toThrow"
 }
 
-@module("@jest/globals") external expect: 'a => Expect.t<'a> = "expect"
+external expect: 'a => expect<'a> = "expect"
 
 // Jest Module
 module JestJs = {
   // mock packages
-  @module("@jest/globals") @scope("jest") external dontMock: string => unit = "dontMock"
-  @module("@jest/globals") @scope("jest") external doMock: string => unit = "doMock"
-  @module("@jest/globals") @scope("jest")
+  @scope("jest") external dontMock: string => unit = "dontMock"
+  @scope("jest") external doMock: string => unit = "doMock"
+  @scope("jest")
   external doMockFactory: (string, unit => 'a) => unit = "doMock"
-  @module("@jest/globals") @scope("jest")
+  @scope("jest")
   external doMockFactoryVirtual: (string, unit => 'a, @as(json`{virtual: true }`) _) => unit =
     "doMock"
 
-  @module("@jest/globals") @scope("jest") external mock: string => unit = "mock"
-  @module("@jest/globals") @scope("jest")
+  @scope("jest") external mock: string => unit = "mock"
+  @scope("jest")
   external mockFactory: (string, unit => 'a) => unit = "mock"
-  @module("@jest/globals") @scope("jest")
+  @scope("jest")
   external mockFactoryVirtual: (string, unit => 'a, @as(json`{virtual: true }`) _) => unit = "mock"
 
-  @module("@jest/globals") @scope("jest") external requireActual: string => 'a = "requireActual"
-  @module("@jest/globals") @scope("jest") external requireMock: string => 'a = "requireMock"
+  @scope("jest") external requireActual: string => 'a = "requireActual"
+  @scope("jest") external requireMock: string => 'a = "requireMock"
 
   // global functions
-  @module("@jest/globals") @scope("jest") external autoMockOff: unit => unit = "autoMockOff"
-  @module("@jest/globals") @scope("jest") external autoMockOn: unit => unit = "autoMockOn"
-  @module("@jest/globals") @scope("jest") external clearAllMocks: unit => unit = "clearAllMocks"
-  @module("@jest/globals") @scope("jest") external resetAllMocks: unit => unit = "resetAllMocks"
-  @module("@jest/globals") @scope("jest") external restoreAllMocks: unit => unit = "restoreAllMocks"
-  @module("@jest/globals") @scope("jest") external clearAllTimers: unit => unit = "clearAllTimers"
-  @module("@jest/globals") @scope("jest") external getTimerCount: unit => unit = "getTimerCount"
-  @module("@jest/globals") @scope("jest") external setSystemTime: int => unit = "setSystemTime"
-  @module("@jest/globals") @scope("jest")
+  @scope("jest") external autoMockOff: unit => unit = "autoMockOff"
+  @scope("jest") external autoMockOn: unit => unit = "autoMockOn"
+  @scope("jest") external clearAllMocks: unit => unit = "clearAllMocks"
+  @scope("jest") external resetAllMocks: unit => unit = "resetAllMocks"
+  @scope("jest") external restoreAllMocks: unit => unit = "restoreAllMocks"
+  @scope("jest") external clearAllTimers: unit => unit = "clearAllTimers"
+  @scope("jest") external getTimerCount: unit => unit = "getTimerCount"
+  @scope("jest") external setSystemTime: int => unit = "setSystemTime"
+  @scope("jest")
   external setSystemDate: Js.Date.t => unit = "setSystemTime"
-  @module("@jest/globals") @scope("jest")
+  @scope("jest")
   external getRealSystemTime: unit => int = "getRealSystemTime"
-  @module("@jest/globals") @scope("jest") external disableAutomock: unit => unit = "disableAutomock"
-  @module("@jest/globals") @scope("jest") external enableAutomock: unit => unit = "enableAutomock"
-  @module("@jest/globals") @scope("jest") external resetModules: unit => unit = "resetModules"
-  @module("@jest/globals") @scope("jest")
+  @scope("jest") external disableAutomock: unit => unit = "disableAutomock"
+  @scope("jest") external enableAutomock: unit => unit = "enableAutomock"
+  @scope("jest") external resetModules: unit => unit = "resetModules"
+  @scope("jest")
   external runAllImmediates: unit => unit = "runAllImmediates"
-  @module("@jest/globals") @scope("jest") external runAllTicks: unit => unit = "runAllTicks"
-  @module("@jest/globals") @scope("jest") external runAllTimers: unit => unit = "runAllTimers"
-  @module("@jest/globals") @scope("jest")
+  @scope("jest") external runAllTicks: unit => unit = "runAllTicks"
+  @scope("jest") external runAllTimers: unit => unit = "runAllTimers"
+  @scope("jest")
   external runOnlyPendingTimers: unit => unit = "runOnlyPendingTimers"
-  @module("@jest/globals") @scope("jest")
+  @scope("jest")
   external advanceTimersByTime: int => unit = "advanceTimersByTime"
-  @module("@jest/globals") @scope("jest")
+  @scope("jest")
   external advanceTimersToNextTimer: int => unit = "advanceTimersToNextTimer"
-  @module("@jest/globals") @scope("jest") external setTimeout: int => unit = "setTimeout"
-  @module("@jest/globals") @scope("jest") external useFakeTimers: unit => unit = "useFakeTimers"
-  @module("@jest/globals") @scope("jest") external useRealTimers: unit => unit = "useRealTimers"
+  @scope("jest") external setTimeout: int => unit = "setTimeout"
+  @scope("jest") external useFakeTimers: unit => unit = "useFakeTimers"
+  @scope("jest") external useRealTimers: unit => unit = "useRealTimers"
 
   type fakeTimerConfig = {
     advanceTimers?: bool,
@@ -328,6 +338,6 @@ module JestJs = {
     now?: @unwrap [#Int(int) | #Date(Js.Date.t)],
     timerLimit?: int,
   }
-  @module("@jest/globals") @scope("jest")
+  @scope("jest")
   external useFakeTimersWithConfig: fakeTimerConfig => unit = "useFakeTimers"
 }


### PR DESCRIPTION
1. `@jest/globals` 에서 가져오는걸 제거합니다. 어차피 jest에서 전역변수에 선언하기에 mjs에서 사용하는게 오류가 났습니다; @sairion 
2. `Mock.fn<'args, 'return>`에서 `Mock.fn<'fn, 'args, 'return>` 으로 개선합니다. 인자의 갯수가 여러개일때 fn 타입을 제대로 못 만드는 문제가 있습니다.
3. `Test.each` 의 타입이 `(array<'a>) => (string, 'a => unit) => unit` 인데, rescript에서 제멋대로 `(array<'a>, string, 'a => unit) => unit` 으로 해석해버려서 배열 인자 갯수만큼 타입을 미리 선언하도록 했습니다.