### PR TITLE
lerna 빌드 오류 우회

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "lerna run build",
+    "build": "lerna run build --concurrency 1  # workaround for rescript build corruption",
     "release": "changeset publish",
     "boot": "yarn --frozen-lockfile && yarn bootstrap",
     "bootstrap": "yarn lerna:bootstrap",


### PR DESCRIPTION
rescript-react-linkify 와 rescript-react-hook-form 두 패키지가 동시에 rescript-webapi 를 빌드하면서 충돌이 발생하는 것으로 추정

```
       rescript: [34/38] src/RescriptReactErrorBoundary.cmj
       FAILED: src/RescriptReactErrorBoundary.cmj

         We've found a bug for you!
         /Users/namenu/green/rescript-bindings/node_modules/@rescript/react/src/RescriptReactErrorBoundary.res

         Corrupted compiled interface
       src/rescriptReactErrorBoundary.cmi
```

concurrency 를 1로 조절하여 해결됨을 확인