### PR TITLE
fix: react-hook-form binding typo

### DIFF
--- a/packages/rescript-react-hook-form/src/ReactHookForm.res
+++ b/packages/rescript-react-hook-form/src/ReactHookForm.res
@@ -183,7 +183,7 @@ module Make = (
     }
 
     let makeRule = (config: Rules.config<T.t, 'b>) => Rules.Any(config)
-    let makeRuleWithErrorMEssage = (config: Rules.configWithErrorMessage<T.t, 'b>) => Rules.Any(
+    let makeRuleWithErrorMessage = (config: Rules.configWithErrorMessage<T.t, 'b>) => Rules.Any(
       config,
     )
 

--- a/packages/rescript-react-hook-form/src/ReactHookForm.resi
+++ b/packages/rescript-react-hook-form/src/ReactHookForm.resi
@@ -129,7 +129,7 @@ module Make: (
   {
     type watchOption = {control: control, name: string}
     let makeRule: Rules.config<T.t, 'b> => Rules.t<'a>
-    let makeRuleWithErrorMEssage: Rules.configWithErrorMessage<T.t, 'b> => Rules.t<'a>
+    let makeRuleWithErrorMessage: Rules.configWithErrorMessage<T.t, 'b> => Rules.t<'a>
     let useWatch: t => T.t
     let watch: t => T.t
     let getValue: t => T.t
@@ -187,7 +187,7 @@ module Make: (
   {
     type watchOption = {control: control, name: string}
     let makeRule: Rules.config<array<T.t>, 'b> => Rules.t<'a>
-    let makeRuleWithErrorMEssage: Rules.configWithErrorMessage<array<T.t>, 'b> => Rules.t<'a>
+    let makeRuleWithErrorMessage: Rules.configWithErrorMessage<array<T.t>, 'b> => Rules.t<'a>
     let useWatch: t => array<T.t>
     let watch: t => array<T.t>
     let getValue: t => array<T.t>


### PR DESCRIPTION
작업내용
-
- `makeRuleWithErrorMEssage` -> `makeRuleWithErrorMessage` 오탈자를 수정합니다.